### PR TITLE
Feature/add extensions

### DIFF
--- a/TinyAggregate.UnitTests/Aggregates/Payment/Event/PaymentTaken.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Payment/Event/PaymentTaken.cs
@@ -1,4 +1,4 @@
-﻿namespace TinyAggregate.UnitTests.Payment.Event
+﻿namespace TinyAggregate.UnitTests.Aggregates.Payment.Event
 {
     public class PaymentTaken : IAcceptVisitors<IPaymentVisitor>
     {

--- a/TinyAggregate.UnitTests/Aggregates/Payment/IPaymentVisitor.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Payment/IPaymentVisitor.cs
@@ -1,0 +1,9 @@
+﻿using TinyAggregate.UnitTests.Aggregates.Payment.Event;
+
+namespace TinyAggregate.UnitTests.Aggregates.Payment
+{
+    public interface IPaymentVisitor
+    {
+        void Accept(PaymentTaken paymentTaken);
+    }
+}

--- a/TinyAggregate.UnitTests/Aggregates/Payment/Payment.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Payment/Payment.cs
@@ -1,8 +1,8 @@
-﻿using TinyAggregate.UnitTests.Payment.Event;
+﻿using TinyAggregate.UnitTests.Aggregates.Payment.Event;
 
-namespace TinyAggregate.UnitTests.Payment
+namespace TinyAggregate.UnitTests.Aggregates.Payment
 {
-    public class PaymentAggregate : Aggregate<IPaymentVisitor>, IPaymentVisitor
+    public class Payment : Aggregate<IPaymentVisitor>, IPaymentVisitor
     {
         internal decimal Amount { get; set; }
 
@@ -14,7 +14,7 @@ namespace TinyAggregate.UnitTests.Payment
             ApplyEvent(domainEvent);
         }
 
-        public void Accept(PaymentTaken paymentTaken)
+        void IPaymentVisitor.Accept(PaymentTaken paymentTaken)
         {
             Amount = paymentTaken.Amount;
             Currency = paymentTaken.Currency;

--- a/TinyAggregate.UnitTests/Aggregates/Transport/Event/EngineStarted.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Transport/Event/EngineStarted.cs
@@ -1,0 +1,10 @@
+﻿namespace TinyAggregate.UnitTests.Aggregates.Transport.Event
+{
+    public class EngineStarted : IAcceptVisitors<IVehicleVisitor>
+    {
+        public void Accept(IVehicleVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/TinyAggregate.UnitTests/Aggregates/Transport/IVehicleVisitor.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Transport/IVehicleVisitor.cs
@@ -1,0 +1,9 @@
+﻿using TinyAggregate.UnitTests.Aggregates.Transport.Event;
+
+namespace TinyAggregate.UnitTests.Aggregates.Transport
+{
+    public interface IVehicleVisitor
+    {
+        void Visit(EngineStarted engineStarted);
+    }
+}

--- a/TinyAggregate.UnitTests/Aggregates/Transport/Vehicle.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Transport/Vehicle.cs
@@ -5,11 +5,9 @@ namespace TinyAggregate.UnitTests.Aggregates.Transport
 {
     public class Vehicle : Aggregate<IVehicleVisitor>
     {
-        private readonly IVehicleVisitor visitor;
-
         public Vehicle(IVehicleVisitor visitor)
         {
-            this.visitor = visitor ?? throw new ArgumentNullException(nameof(visitor));
+            this.Visitor = visitor ?? throw new ArgumentNullException(nameof(visitor));
         }
 
         public void StartTheEngine()
@@ -17,9 +15,14 @@ namespace TinyAggregate.UnitTests.Aggregates.Transport
             ApplyEvent(new EngineStarted());
         }
 
-        protected override IVehicleVisitor GetVisitor()
+        /// <summary>
+        /// Added to assist unit tests
+        /// </summary>
+        public void ApplyEventForUnitTests(IAcceptVisitors<IVehicleVisitor> domainEvent)
         {
-            return visitor;
+            ApplyEvent(domainEvent);
         }
+
+        protected override IVehicleVisitor Visitor { get; }
     }
 }

--- a/TinyAggregate.UnitTests/Aggregates/Transport/Vehicle.cs
+++ b/TinyAggregate.UnitTests/Aggregates/Transport/Vehicle.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using TinyAggregate.UnitTests.Aggregates.Transport.Event;
+
+namespace TinyAggregate.UnitTests.Aggregates.Transport
+{
+    public class Vehicle : Aggregate<IVehicleVisitor>
+    {
+        private readonly IVehicleVisitor visitor;
+
+        public Vehicle(IVehicleVisitor visitor)
+        {
+            this.visitor = visitor ?? throw new ArgumentNullException(nameof(visitor));
+        }
+
+        public void StartTheEngine()
+        {
+            ApplyEvent(new EngineStarted());
+        }
+
+        protected override IVehicleVisitor GetVisitor()
+        {
+            return visitor;
+        }
+    }
+}

--- a/TinyAggregate.UnitTests/Payment/IPaymentVisitor.cs
+++ b/TinyAggregate.UnitTests/Payment/IPaymentVisitor.cs
@@ -1,9 +1,0 @@
-﻿using TinyAggregate.UnitTests.Payment.Event;
-
-namespace TinyAggregate.UnitTests.Payment
-{
-    public interface IPaymentVisitor
-    {
-        void Accept(PaymentTaken paymentTaken);
-    }
-}

--- a/TinyAggregate.UnitTests/TinyAggregate.UnitTests.csproj
+++ b/TinyAggregate.UnitTests/TinyAggregate.UnitTests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
   </ItemGroup>

--- a/TinyAggregate/Aggregate.cs
+++ b/TinyAggregate/Aggregate.cs
@@ -33,6 +33,5 @@ namespace TinyAggregate
         {
             uncommitedEvents.Clear();
         }
-
     }
 }

--- a/TinyAggregate/Aggregate.cs
+++ b/TinyAggregate/Aggregate.cs
@@ -12,9 +12,11 @@ namespace TinyAggregate
 
         IEnumerable<IAcceptVisitors<TVisitor>> IAggregate<TVisitor>.UncommitedEvents => uncommitedEvents;
 
+        protected virtual TVisitor Visitor => this as TVisitor ?? throw new InvalidOperationException($"{nameof(Visitor)} was about to return null. If your aggregate doesn't implement the TVisitor inerface then you must override {nameof(Visitor)} and return the TVisitor instance manually.");
+
         void IAggregate<TVisitor>.Replay(int loadedVersion, IEnumerable<IAcceptVisitors<TVisitor>> events)
         {
-            var visitor = GetVisitor();
+            var visitor = Visitor;
             foreach (var domainEvent in events)
             {
                 ApplyEvent(domainEvent, visitor);
@@ -25,17 +27,12 @@ namespace TinyAggregate
         protected void ApplyEvent(IAcceptVisitors<TVisitor> domainEvent)
         {
             uncommitedEvents.Add(domainEvent);
-            ApplyEvent(domainEvent, GetVisitor());
+            ApplyEvent(domainEvent, Visitor);
         }
 
         void IAggregate<TVisitor>.ClearUncommitedEvents()
         {
             uncommitedEvents.Clear();
-        }
-
-        protected virtual TVisitor GetVisitor()
-        {
-            return this as TVisitor ?? throw new InvalidOperationException($"{nameof(GetVisitor)} was about to return null. If your aggregate doesn't implement the TVisitor inerface then you must override {nameof(GetVisitor)} and return the TVisitor instance manually.");
         }
 
         private void ApplyEvent(IAcceptVisitors<TVisitor> domainEvent, TVisitor visitor)

--- a/TinyAggregate/AggregateTestingExtensions.cs
+++ b/TinyAggregate/AggregateTestingExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace TinyAggregate
+{
+    public static class AggregateTestingExtensions
+    {
+        public static IAggregate<TVisitor> ToAggregate<TVisitor>(this Aggregate<TVisitor> aggregate) where TVisitor : class
+        {
+            return aggregate;
+        }
+    }
+}

--- a/TinyAggregate/IAggregate.cs
+++ b/TinyAggregate/IAggregate.cs
@@ -2,7 +2,7 @@
 
 namespace TinyAggregate
 {
-    public interface IAggregate<TVisitor>
+    public interface IAggregate<TVisitor> where TVisitor : class
     {
         IEnumerable<IAcceptVisitors<TVisitor>> UncommitedEvents { get; }
 

--- a/TinyAggregate/TinyAggregate.csproj
+++ b/TinyAggregate/TinyAggregate.csproj
@@ -12,4 +12,8 @@
     <Description>Tiny Domain Driven Design (DDD) Aggregate designed to simplify development when using an event sourcing pattern.</Description>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>default</LangVersion>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Simplified how the visitor can be provided.
Also simplified getting access to the IAggregate<T> instance by using the ToAggregate() extension method.
Increased test coverage.